### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.rhel
+++ b/Dockerfile.rhel
@@ -1,6 +1,6 @@
 # base image sources https://github.com/rhdt/EL-Dockerfiles/tree/master/base/fabric8-analytics-stack-report-ui
 
-FROM prod.registry.devshift.net/osio-prod/base/fabric8-analytics-stack-report-ui:latest
+FROM quay.io/openshiftio/rhel-base-fabric8-analytics-stack-report-ui:latest
 
 RUN mkdir -p /opt/scripts /var/www/html
 

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
-ifeq ($(TARGET),rhel)
-  DOCKERFILE := Dockerfile.rhel
-  REGISTRY := push.registry.devshift.net/osio-prod
-else
-  DOCKERFILE := Dockerfile
-  REGISTRY := push.registry.devshift.net
-endif
-REPOSITORY?=fabric8-analytics-stack-report-ui
+REGISTRY := quay.io
 DEFAULT_TAG=latest
 REPOSITORY_UI_TESTS?=fabric8-analytics-stack-report-ui-tests
+
+ifeq ($(TARGET),rhel)
+  DOCKERFILE := Dockerfile.rhel
+  REPOSITORY := openshiftio/rhel-fabric8-analytics-stack-report-ui
+else
+  DOCKERFILE := Dockerfile
+  REPOSITORY := openshiftio/fabric8-analytics-stack-report-ui
+endif
 
 .PHONY: all docker-build fast-docker-build test get-image-name get-image-repository
 

--- a/cico_setup.sh
+++ b/cico_setup.sh
@@ -1,12 +1,20 @@
 #!/bin/bash -ex
 
 load_jenkins_vars() {
-    if [ -e "jenkins-env" ]; then
-        cat jenkins-env \
-          | grep -E "(DEVSHIFT_TAG_LEN|DEVSHIFT_USERNAME|DEVSHIFT_PASSWORD|JENKINS_URL|GIT_BRANCH|GIT_COMMIT|BUILD_NUMBER|ghprbSourceBranch|ghprbActualCommit|BUILD_URL|ghprbPullId|RECOMMENDER_API_TOKEN)=" \
-          | sed 's/^/export /g' \
-          > ~/.jenkins-env
-        source ~/.jenkins-env
+    if [ -e "jenkins-env.json" ]; then
+        eval "$(./env-toolkit load -f jenkins-env.json \
+                DEVSHIFT_TAG_LEN \
+                QUAY_USERNAME \
+                QUAY_PASSWORD \
+                JENKINS_URL \
+                GIT_BRANCH \
+                GIT_COMMIT \
+                BUILD_NUMBER \
+                ghprbSourceBranch \
+                ghprbActualCommit \
+                BUILD_URL \
+                ghprbPullId \
+                RECOMMENDER_API_TOKEN)"
     fi
 }
 
@@ -77,8 +85,8 @@ build_image() {
     local push_registry
     push_registry=$(make get-push-registry)
     # login before build to be able to pull RHEL parent image
-    if [ -n "${DEVSHIFT_USERNAME}" -a -n "${DEVSHIFT_PASSWORD}" ]; then
-        docker login -u ${DEVSHIFT_USERNAME} -p ${DEVSHIFT_PASSWORD} ${push_registry}
+    if [ -n "${QUAY_USERNAME}" -a -n "${QUAY_PASSWORD}" ]; then
+        docker login -u ${QUAY_USERNAME} -p ${QUAY_PASSWORD} ${push_registry}
     else
         echo "Could not login, missing credentials for the registry"
         exit 1
@@ -102,9 +110,10 @@ push_image() {
     local image_repository
     local short_commit
     local push_registry
+
     image_name=$(make get-image-name)
     image_repository=$(make get-image-repository)
-    short_commit=$(git rev-parse --short=7 HEAD)
+    short_commit=$(git rev-parse --short=$DEVSHIFT_TAG_LEN HEAD)
     push_registry=$(make get-push-registry)
 
     if [ -n "${ghprbPullId}" ]; then

--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -91,13 +91,13 @@ parameters:
   displayName: Docker registry
   required: true
   name: DOCKER_REGISTRY
-  value: "registry.devshift.net"
+  value: "quay.io"
 
 - description: Docker image to use
   displayName: Docker image
   required: true
   name: DOCKER_IMAGE
-  value: "fabric8-analytics-stack-report-ui"
+  value: "openshiftio/rhel-fabric8-analytics-stack-report-ui"
 
 - description: Image tag
   displayName: Image tag


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to
change the staging url from devshift to quay. The PR to the saas repo should be
merged before this one.
https://github.com/openshiftio/saas-analytics/pull/416