### PR TITLE
fix(title): Fix CVE affected component listing title

### DIFF
--- a/src/app/stack/card-details/card-details.component.ts
+++ b/src/app/stack/card-details/card-details.component.ts
@@ -286,7 +286,7 @@ export class CardDetailsComponent implements OnInit, OnChanges {
                 compDetails = this.getDirectDependencySecurityDetails(genericReport.componentDetails);
                 reportInformations.push(new MReportInformation(
                     'comp-direct-security',
-                    'Security Issues In Direct Dependency',
+                    'Direct Dependencies with Security Issues',
                     'component',
                     this.fillColumnHeaders(cardType, 2),
                     compDetails
@@ -295,7 +295,7 @@ export class CardDetailsComponent implements OnInit, OnChanges {
                 if (compDetails && compDetails.length > 0) {
                     reportInformations.push(new MReportInformation(
                         'comp-trans-security',
-                        'Security Issues In Transitive Dependency',
+                        'Transitive Dependencies with Security Issues',
                         'component',
                         this.fillColumnHeaders(cardType, 3),
                         compDetails


### PR DESCRIPTION
This change has been requested by @parag dave.

### Before
<img width="1552" alt="Screen Shot 2019-08-26 at 1 10 00 PM" src="https://user-images.githubusercontent.com/3874763/63673852-db861c80-c802-11e9-894c-5d4daf3b85f0.png">


### After

<img width="1552" alt="Screen Shot 2019-08-26 at 1 07 52 PM" src="https://user-images.githubusercontent.com/3874763/63673775-abd71480-c802-11e9-98e1-a2fc8cfb4c4f.png">

This PR fixes https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/335