### PR TITLE
fix: Remove Github stats and Licenses details from security card

### DIFF
--- a/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
+++ b/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
@@ -78,7 +78,7 @@
         </div>
     </div>
 
-    <div *ngIf="view === 'normal' && !component.isTransitive && tabType =='compDetails'" class="github-osio-box">
+    <div *ngIf="view === 'normal' && tabType =='compDetails'" class="github-osio-box">
         <div class="github left">
             <div class="box-header">
                 GitHub Statistics:
@@ -121,14 +121,11 @@
                 <span class="info-head">Vulnerabilities:</span>
                 <span class="common-container">
                     <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
-                        <!-- <span class="severity"
-                        [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}"> -->
+                       
                         <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
                         <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
                         <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
                         <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'"></span>
-                        <!-- <span [innerText]="cve.severity"></span> -->
-                        <!-- </span> -->
                         <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
                                 target="_blank">{{cve.title}}</a>
                             <div class="custom-tooltip-wrapper">
@@ -147,7 +144,7 @@
                             </div>
                         </span>
                     </span>
-                    <a class="name" *ngIf="component?.private_vulnerabilities?.length>0"
+                    <a class="name" *ngIf="component?.private_vulnerabilities?.length > 0"
                         [href]="getUrl(component.url, tabType, component?.registrationStatus)" target="_blank"
                         title="command/ctrl + click">
                         Sign up with Snyk

--- a/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
+++ b/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
@@ -78,8 +78,7 @@
         </div>
     </div>
 
-    <div *ngIf="view === 'normal' && !component.isTransitive && (tabType == 'private' || tabType =='public' || tabType =='compDetails')"
-        class="github-osio-box">
+    <div *ngIf="view === 'normal' && !component.isTransitive && tabType =='compDetails'" class="github-osio-box">
         <div class="github left">
             <div class="box-header">
                 GitHub Statistics:
@@ -114,132 +113,8 @@
         </div>
     </div>
     <div [ngClass]="component.isTransitive?'transitive-details' : null">
-        <div class="common-table component-tags">
-            <div class="common-wrapper"
-                *ngIf="component?.registrationStatus !== 'registered' &&(component?.public_vulnerabilities?.length > 0) && tabType == 'public'">
-                <span class="info-head">Vulnerabilities:</span>
-                <span class="common-container">
-                    <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
-
-                        <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"
-                            title="Critical"></span>
-                        <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'" title="High"></span>
-                        <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"
-                            title="Medium"></span>
-                        <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'" title="Low">
-                        </span>
-                        <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
-                                target="_blank">{{cve.title}}</a>
-                            <div class="custom-tooltip-wrapper">
-                                <div class="custom-tooltip-text no-wrap">
-                                    <span class="head">CVSS Score:</span>
-                                    <span class="score">{{cve.cvss}}</span>
-                                </div>
-                                <div class="custom-tooltip-text no-wrap">
-                                    <span class="head">Snyk ID:</span>
-                                    <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
-                                            [innerText]="cve.id"></a></span>
-                                </div>
-                                <div class="footer no-wrap">
-                                    <span class="click">(cmd/ctrl + click)</span>
-                                </div>
-                            </div>
-                        </span>
-                    </span>
-                    <br>
-                    <span class="common-container box">
-                        <span>
-                            <img src="/assets/icon/snyk-avatar.png" alt="snyk-avatar" class="avatar" />
-                        </span>
-                        <a [href]="this.generateUrl.registrationURL" target="_blank" title="command/ctrl + click" class="branding-url">
-                            Sign up for a free Snyk account
-                        </a>
-                        to find out which vulnerabilities have a publicly known exploits
-                    </span>
-                </span>
-            </div>
-
-            <div class="common-wrapper"
-                *ngIf="component?.registrationStatus !== 'registered' && (component?.private_vulnerabilities?.length > 0) && tabType == 'private'">
-                <span class="info-head">Vulnerabilities:</span>
-                <span class="common-container box">
-                    <span>
-                        <img src="/assets/icon/snyk-avatar.png" alt="snyk-avatar" class="avatar" />
-                    </span>
-                    <a [href]="this.generateUrl.registrationURL" target="_blank" title="command/ctrl + click" class="branding-url">
-                        Sign up for a free Snyk account
-                    </a>
-                    to find out about the vulnerabilities that have been found, and whether any have a publicly known exploit
-                </span>
-            </div>
-
-            <div class="common-wrapper"
-                *ngIf="component?.registrationStatus == 'registered' && (component?.public_vulnerabilities?.length > 0) && tabType == 'public'">
-                <span class="info-head">Vulnerabilities:</span>
-                <span class="common-container">
-                    <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
-                        <span class="severity"
-                            [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}">
-                            <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
-                            <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
-                            <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
-                            <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'"></span>
-                            <span [innerText]="cve.exploit"></span>
-                        </span>
-                        <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
-                                target="_blank">{{cve.title}}</a>
-                            <div class="custom-tooltip-wrapper">
-                                <div class="custom-tooltip-text no-wrap">
-                                    <span class="head">CVSS Score:</span>
-                                    <span class="score">{{cve.cvss}}</span>
-                                </div>
-                                <div class="custom-tooltip-text no-wrap">
-                                    <span class="head">Snyk ID:</span>
-                                    <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
-                                            [innerText]="cve.id"></a></span>
-                                </div>
-                                <div class="footer no-wrap">
-                                    <span class="click">(cmd/ctrl + click)</span>
-                                </div>
-                            </div>
-                        </span>
-                    </span>
-                </span>
-            </div>
-
-
-            <div class="common-wrapper"
-                *ngIf="component?.registrationStatus == 'registered' && (component?.private_vulnerabilities?.length > 0) && tabType =='private'">
-                <span class="info-head">Vulnerabilities:</span>
-                <span *ngFor="let cve of component?.private_vulnerabilities" class="wrapper">
-                    <span class="severity"
-                        [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}">
-                        <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
-                        <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
-                        <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
-                        <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'"></span>
-                        <span [innerText]="cve.exploit"></span>
-                    </span>
-                    <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
-                            target="_blank">{{cve.title}}</a>
-                        <div class="custom-tooltip-wrapper">
-                            <div class="custom-tooltip-text no-wrap">
-                                <span class="head">CVSS Score:</span>
-                                <span class="score">{{cve.cvss}}</span>
-                            </div>
-                            <div class="custom-tooltip-text no-wrap">
-                                <span class="head">Snyk ID:</span>
-                                <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
-                                        [innerText]="cve.id"></a></span>
-                            </div>
-                            <div class="footer no-wrap">
-                                <span class="click">(cmd/ctrl + click)</span>
-                            </div>
-                        </div>
-                    </span>
-                </span>
-            </div>
-
+        <div *ngIf="tabType == 'compDetails' && (component?.public_vulnerabilities?.length > 0 || component?.private_vulnerabilities?.length > 0)"
+            class="common-table component-tags">
 
             <div class="common-wrapper"
                 *ngIf="component?.registrationStatus !== 'registered' && (component?.public_vulnerabilities?.length > 0 || component?.private_vulnerabilities?.length > 0) && tabType=='compDetails'">
@@ -247,7 +122,7 @@
                 <span class="common-container">
                     <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
                         <!-- <span class="severity"
-                            [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}"> -->
+                        [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}"> -->
                         <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
                         <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
                         <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
@@ -342,9 +217,142 @@
                 </span>
             </div>
 
+
         </div>
 
-        <div class="common-table component-licenses">
+        <div class="github left">
+            <div class="common-wrapper"
+                *ngIf="component?.registrationStatus !== 'registered' &&(component?.public_vulnerabilities?.length > 0) && tabType == 'public'">
+                <span class="info-head">Vulnerabilities:</span>
+                <span class="common-container">
+                    <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
+
+                        <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"
+                            title="Critical"></span>
+                        <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'" title="High"></span>
+                        <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"
+                            title="Medium"></span>
+                        <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'" title="Low">
+                        </span>
+                        <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
+                                target="_blank">{{cve.title}}</a>
+                            <div class="custom-tooltip-wrapper">
+                                <div class="custom-tooltip-text no-wrap">
+                                    <span class="head">CVSS Score:</span>
+                                    <span class="score">{{cve.cvss}}</span>
+                                </div>
+                                <div class="custom-tooltip-text no-wrap">
+                                    <span class="head">Snyk ID:</span>
+                                    <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
+                                            [innerText]="cve.id"></a></span>
+                                </div>
+                                <div class="footer no-wrap">
+                                    <span class="click">(cmd/ctrl + click)</span>
+                                </div>
+                            </div>
+                        </span>
+                    </span>
+                    <br>
+                    <span class="common-container box">
+                        <span>
+                            <img src="/assets/icon/snyk-avatar.png" alt="snyk-avatar" class="avatar" />
+                        </span>
+                        <a [href]="this.generateUrl.registrationURL" target="_blank" title="command/ctrl + click"
+                            class="branding-url">
+                            Sign up for a free Snyk account
+                        </a>
+                        to find out which vulnerabilities have a publicly known exploits
+                    </span>
+                </span>
+            </div>
+
+            <div class="common-wrapper"
+                *ngIf="component?.registrationStatus !== 'registered' && (component?.private_vulnerabilities?.length > 0) && tabType == 'private'">
+                <span class="info-head">Vulnerabilities:</span>
+                <span class="common-container box">
+                    <span>
+                        <img src="/assets/icon/snyk-avatar.png" alt="snyk-avatar" class="avatar" />
+                    </span>
+                    <a [href]="this.generateUrl.registrationURL" target="_blank" title="command/ctrl + click"
+                        class="branding-url">
+                        Sign up for a free Snyk account
+                    </a>
+                    to find out about the vulnerabilities that have been found, and whether any have a publicly known
+                    exploit
+                </span>
+            </div>
+
+            <div class="common-wrapper"
+                *ngIf="component?.registrationStatus == 'registered' && (component?.public_vulnerabilities?.length > 0) && tabType == 'public'">
+                <span class="info-head">Vulnerabilities:</span>
+                <span class="common-container">
+                    <span *ngFor="let cve of component?.public_vulnerabilities" class="wrapper">
+                        <span class="severity"
+                            [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}">
+                            <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
+                            <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
+                            <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
+                            <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'"></span>
+                            <span [innerText]="cve.exploit"></span>
+                        </span>
+                        <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
+                                target="_blank">{{cve.title}}</a>
+                            <div class="custom-tooltip-wrapper">
+                                <div class="custom-tooltip-text no-wrap">
+                                    <span class="head">CVSS Score:</span>
+                                    <span class="score">{{cve.cvss}}</span>
+                                </div>
+                                <div class="custom-tooltip-text no-wrap">
+                                    <span class="head">Snyk ID:</span>
+                                    <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
+                                            [innerText]="cve.id"></a></span>
+                                </div>
+                                <div class="footer no-wrap">
+                                    <span class="click">(cmd/ctrl + click)</span>
+                                </div>
+                            </div>
+                        </span>
+                    </span>
+                </span>
+            </div>
+
+
+            <div class="common-wrapper"
+                *ngIf="component?.registrationStatus == 'registered' && (component?.private_vulnerabilities?.length > 0) && tabType =='private'">
+                <span class="info-head">Vulnerabilities:</span>
+                <span *ngFor="let cve of component?.private_vulnerabilities" class="wrapper">
+                    <span class="severity"
+                        [ngClass]="{'critical':cve.severity == 'critical', 'high':cve.severity == 'high','medium':cve.severity == 'medium','low':cve.severity == 'low'}">
+                        <span *ngIf="cve.severity == 'critical'" class="circle critical" [innerText]="'C'"></span>
+                        <span *ngIf="cve.severity == 'high'" class="circle high" [innerText]="'H'"></span>
+                        <span *ngIf="cve.severity == 'medium'" class="circle medium" [innerText]="'M'"></span>
+                        <span *ngIf="cve.severity == 'low'" class="circle low" [innerText]="'L'"></span>
+                        <span [innerText]="cve.exploit"></span>
+                    </span>
+                    <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
+                            target="_blank">{{cve.title}}</a>
+                        <div class="custom-tooltip-wrapper">
+                            <div class="custom-tooltip-text no-wrap">
+                                <span class="head">CVSS Score:</span>
+                                <span class="score">{{cve.cvss}}</span>
+                            </div>
+                            <div class="custom-tooltip-text no-wrap">
+                                <span class="head">Snyk ID:</span>
+                                <span class="url"><a [href]="getUrl(cve.url, tabType)" target="_blank"
+                                        [innerText]="cve.id"></a></span>
+                            </div>
+                            <div class="footer no-wrap">
+                                <span class="click">(cmd/ctrl + click)</span>
+                            </div>
+                        </div>
+                    </span>
+                </span>
+            </div>
+
+        </div>
+
+        <div *ngIf="view === 'normal' && tabType =='compDetails'|| !(tabType == 'private' || tabType =='public' || tabType =='compDetails')"
+            class="common-table component-licenses">
             <div class="common-wrapper">
                 <span class="info-head">License(s) used: </span>
                 <span *ngIf="component?.licenses?.length > 0" class="common-container license-container">


### PR DESCRIPTION
# Discription

Removed Github Status and Licenses from Security tab and made vulnerability details come after recommended versions card in security details card 

- [X] Removed Github Status 
- [X]  Removed Licenses 
- [X]  Moved Vulnerbility details card to left 