### PR TITLE
fix: Rename exploit to proper text

### DIFF
--- a/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
+++ b/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.html
@@ -130,7 +130,7 @@
                                 <span *ngIf="cve.severity == 'high'" class="md-chip-icon high" [innerText]="'H'"></span>
                                 <span *ngIf="cve.severity == 'medium'" class="md-chip-icon medium" [innerText]="'M'"></span>
                                 <span *ngIf="cve.severity == 'low'" class="md-chip-icon low" [innerText]="'L'"></span>
-                              <span> {{cve.exploit}} </span>
+                              <span> {{renameExploit(cve.exploit)}} </span>
                             </span>
                         </span>
                         <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType, component?.registrationStatus)"
@@ -156,7 +156,7 @@
                                 <span *ngIf="cve.severity == 'high'" class="md-chip-icon high" [innerText]="'H'"></span>
                                 <span *ngIf="cve.severity == 'medium'" class="md-chip-icon medium" [innerText]="'M'"></span>
                                 <span *ngIf="cve.severity == 'low'" class="md-chip-icon low" [innerText]="'L'"></span>
-                              <span> {{cve.exploit}} </span>
+                              <span> {{renameExploit(cve.exploit)}} </span>
                             </span>
                         </span>
                         <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType, component?.registrationStatus)"
@@ -246,7 +246,7 @@
                                 <span *ngIf="cve.severity == 'high'" class="md-chip-icon high" [innerText]="'H'"></span>
                                 <span *ngIf="cve.severity == 'medium'" class="md-chip-icon medium" [innerText]="'M'"></span>
                                 <span *ngIf="cve.severity == 'low'" class="md-chip-icon low" [innerText]="'L'"></span>
-                              <span> {{cve.exploit}} </span>
+                              <span> {{renameExploit(cve.exploit)}} </span>
                             </span>
                         </span>
                         <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType)"
@@ -278,7 +278,7 @@
                             <span *ngIf="cve.severity == 'high'" class="md-chip-icon high" [innerText]="'H'"></span>
                             <span *ngIf="cve.severity == 'medium'" class="md-chip-icon medium" [innerText]="'M'"></span>
                             <span *ngIf="cve.severity == 'low'" class="md-chip-icon low" [innerText]="'L'"></span>
-                          <span> {{cve.exploit}} </span>
+                          <span> {{renameExploit(cve.exploit)}} </span>
                         </span>
                     </span>
                     <span class="custom-tooltip name"><a [href]="getUrl(cve.url, tabType, component?.registrationStatus)"

--- a/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.ts
+++ b/src/app/stack/card-details/component-information/component-snippet/component-snippet.component.ts
@@ -28,7 +28,6 @@ export class ComponentSnippetComponent implements OnInit, OnChanges {
 
     public generateUrl = new GenerateUrl();
 
-
     public githubKeys: any = {
         contributors: 'Contributors',
         forks: 'Forks',
@@ -55,7 +54,6 @@ export class ComponentSnippetComponent implements OnInit, OnChanges {
         let summary: any = changes['component'];
         if (summary) {
             this.component = <MComponentInformation>summary.currentValue;
-
         }
         console.log("component==>>", this.component);
         
@@ -75,6 +73,22 @@ export class ComponentSnippetComponent implements OnInit, OnChanges {
             } else {
                 return this.generateUrl.privateUrl(url, registrationStatus);
             }
+        }
+    }
+
+    /**
+     * replaceNotDefined functional
+     */
+    public renameExploit(exploit: string): string {
+        switch (exploit) {
+            case "Not Defined":
+                return "No known exploit";
+            case "Functional":
+                return "Mature";
+            case "High":
+                return "Mature";
+            default:
+                return exploit
         }
     }
 


### PR DESCRIPTION
ss1
![image](https://user-images.githubusercontent.com/23407383/103735422-0c3fae00-5014-11eb-9d81-c06272340e68.png)

ss2
![image](https://user-images.githubusercontent.com/23407383/103735464-24173200-5014-11eb-93bd-6f66d7a37bbc.png)
